### PR TITLE
Change output representation of edges to Kececioglu-Myers (bcalm issue 42)

### DIFF
--- a/gatb-core/doc/doxygen/src/dbgh5page.hpp
+++ b/gatb-core/doc/doxygen/src/dbgh5page.hpp
@@ -91,6 +91,8 @@
           -verbose           (1 arg) :    verbosity level  [default '1']
           -email             (1 arg) :    send statistics to the given email address  [default '']
           -email-fmt         (1 arg) :    'raw' or 'xml'  [default 'raw']
+          -edge-km           (1 arg) :    Kececioglu-Myers edge representation  [default '0']
+ 
  * \endcode
  *
  *

--- a/gatb-core/src/gatb/debruijn/impl/Graph.cpp
+++ b/gatb-core/src/gatb/debruijn/impl/Graph.cpp
@@ -648,6 +648,7 @@ IOptionsParser* GraphTemplate<Node, Edge, GraphDataVariant>::getOptionsParser (b
     IOptionsParser* parserGeneral  = new OptionsParser ("general");
     parserGeneral->push_front (new OptionOneParam (STR_INTEGER_PRECISION, "integers precision (0 for optimized value)", false, "0", false));
     parserGeneral->push_front (new OptionOneParam (STR_VERBOSE,           "verbosity level",      false, "1"  ));
+    parserGeneral->push_front (new OptionOneParam (STR_EDGE_KM_REPRESENTATION,           "edge km representation",      false, "0"  ));
     parserGeneral->push_front (new OptionOneParam (STR_NB_CORES,          "number of cores",      false, "0"  ));
     parserGeneral->push_front (new OptionNoParam  (STR_CONFIG_ONLY,       "dump config only"));
     

--- a/gatb-core/src/gatb/debruijn/impl/LinkTigs.hpp
+++ b/gatb-core/src/gatb/debruijn/impl/LinkTigs.hpp
@@ -30,10 +30,10 @@ namespace gatb { namespace core { namespace debruijn { namespace impl  {
 
 
     template<size_t SPAN>
-    void link_tigs( std::string prefix, int kmerSize, int nb_threads, uint64_t &nb_unitigs, bool verbose, bool renumber_unitigs = false);
+    void link_tigs( std::string prefix, int kmerSize, int nb_threads, uint64_t &nb_unitigs, bool verbose,  bool edge_km_representation, bool renumber_unitigs = false);
 
     template<size_t span>
-    void link_unitigs_pass(const std::string unitigs_filename, bool verbose, const int pass, const int kmerSize, const bool renumber_unitigs);
+    void link_unitigs_pass(const std::string unitigs_filename, bool verbose, const int pass, const int kmerSize,  bool edge_km_representation, const bool renumber_unitigs );
     
 }}}}
 

--- a/gatb-core/src/gatb/debruijn/impl/UnitigsConstructionAlgorithm.cpp
+++ b/gatb-core/src/gatb/debruijn/impl/UnitigsConstructionAlgorithm.cpp
@@ -102,6 +102,7 @@ void UnitigsConstructionAlgorithm<span>::execute ()
     int minimizer_type =
         getInput()->getInt(STR_MINIMIZER_TYPE);
     bool verbose = getInput()->getInt(STR_VERBOSE);
+    bool edge_km_representation = getInput()->getInt(STR_EDGE_KM_REPRESENTATION);
     int nb_glue_partitions = 0;
     if (getInput()->get("-nb-glue-partitions"))
         nb_glue_partitions = getInput()->getInt("-nb-glue-partitions");
@@ -112,7 +113,7 @@ void UnitigsConstructionAlgorithm<span>::execute ()
 
     if (do_bcalm) bcalm2<span>(&_storage, unitigs_filename, kmerSize, abundance, minimizerSize, nbThreads, minimizer_type, verbose); 
     if (do_bglue) bglue<span> (&_storage, unitigs_filename, kmerSize, nb_glue_partitions,       nbThreads,                 verbose);
-    if (do_links) link_tigs<span>(unitigs_filename, kmerSize, nbThreads, nb_unitigs, verbose);
+    if (do_links) link_tigs<span>(unitigs_filename, kmerSize, nbThreads, nb_unitigs, verbose, edge_km_representation);
 
     /** We gather some statistics. */
     // nb_unitigs will be used in GraphUnitigs

--- a/gatb-core/src/gatb/template/TemplateSpecialization10.cpp.in
+++ b/gatb-core/src/gatb/template/TemplateSpecialization10.cpp.in
@@ -31,9 +31,9 @@ template void bglue<${KSIZE}>(Storage* storage,
 template class graph3<${KSIZE}>; // graph3<span> switch  
 
 template void link_tigs<${KSIZE}>
-    (std::string unitigs_filename, int kmerSize, int nb_threads, uint64_t &nb_unitigs, bool verbose, bool renumber_unitigs = false);
+    (std::string unitigs_filename, int kmerSize, int nb_threads, uint64_t &nb_unitigs, bool verbose, bool edge_km_representation, bool renumber_unitigs = false);
 
-template void link_unitigs_pass<${KSIZE}>(const std::string unitigs_filename, bool verbose, const int pass, const int kmerSize, const bool renumber_unitigs);
+template void link_unitigs_pass<${KSIZE}>(const std::string unitigs_filename, bool verbose, const int pass, const int kmerSize, bool edge_km_representation, const bool renumber_unitigs);
 
 
 /********************************************************************************/

--- a/gatb-core/src/gatb/tools/misc/api/StringsRepository.hpp
+++ b/gatb-core/src/gatb/tools/misc/api/StringsRepository.hpp
@@ -83,6 +83,7 @@ public:
     const char* graph          ()  { return "-graph";          }
     const char* kmer_size      ()  { return "-kmer-size";      }
     const char* minimizer_size ()  { return "-minimizer-size"; }
+    const char* edge_km_representation ()  { return "-edge-km"; }
     const char* kmer_abundance ()  { return "-abundance"; }
     const char* kmer_abundance_min ()  { return "-abundance-min"; }
     const char* kmer_abundance_min_threshold ()  { return "-abundance-min-threshold"; }
@@ -138,6 +139,7 @@ public:
 #define STR_URI_GRAPH           gatb::core::tools::misc::StringRepository::singleton().graph ()
 #define STR_KMER_SIZE           gatb::core::tools::misc::StringRepository::singleton().kmer_size ()
 #define STR_MINIMIZER_SIZE      gatb::core::tools::misc::StringRepository::singleton().minimizer_size ()
+#define STR_EDGE_KM_REPRESENTATION      gatb::core::tools::misc::StringRepository::singleton().edge_km_representation ()
 #define STR_INTEGER_PRECISION   gatb::core::tools::misc::StringRepository::singleton().integer_precision ()
 #define STR_KMER_ABUNDANCE      gatb::core::tools::misc::StringRepository::singleton().kmer_abundance ()
 #define STR_KMER_ABUNDANCE_MIN  gatb::core::tools::misc::StringRepository::singleton().kmer_abundance_min ()

--- a/gatb-core/src/gatb/tools/misc/impl/Tool.cpp
+++ b/gatb-core/src/gatb/tools/misc/impl/Tool.cpp
@@ -57,8 +57,7 @@ Tool::Tool (const std::string& name) : userDisplayHelp(0), _helpTarget(0),userDi
 
     getParser()->push_back (new OptionOneParam (STR_NB_CORES,    "number of cores",      false, "0"  ));
     getParser()->push_back (new OptionOneParam (STR_VERBOSE,     "verbosity level",      false, "1"  ));
-    getParser()->push_back (new OptionOneParam (STR_EDGE_KM_REPRESENTATION,     "edge representation (KM)",      false, "0"  ));
-	
+	getParser()->push_back (new OptionOneParam (STR_EDGE_KM_REPRESENTATION,     "edge representation (KM)",      false, "0"  ));
 	getParser()->push_back (new OptionNoParam (STR_VERSION, "version", false));
 	getParser()->push_back (new OptionNoParam (STR_HELP, "help", false));
 

--- a/gatb-core/src/gatb/tools/misc/impl/Tool.cpp
+++ b/gatb-core/src/gatb/tools/misc/impl/Tool.cpp
@@ -57,6 +57,7 @@ Tool::Tool (const std::string& name) : userDisplayHelp(0), _helpTarget(0),userDi
 
     getParser()->push_back (new OptionOneParam (STR_NB_CORES,    "number of cores",      false, "0"  ));
     getParser()->push_back (new OptionOneParam (STR_VERBOSE,     "verbosity level",      false, "1"  ));
+    getParser()->push_back (new OptionOneParam (STR_EDGE_KM_REPRESENTATION,     "edge representation (KM)",      false, "0"  ));
 	
 	getParser()->push_back (new OptionNoParam (STR_VERSION, "version", false));
 	getParser()->push_back (new OptionNoParam (STR_HELP, "help", false));


### PR DESCRIPTION
@rchikhi, this pull request is for adding the feature discussed in [https://github.com/GATB/bcalm/issues/42](https://github.com/GATB/bcalm/issues/42). To get KM (Kececioglu-Myers) edge representation in output, we need to run bcalm with "-edge-km 1" option.