### PR TITLE
Short term fix for undefined function on ARM Mac

### DIFF
--- a/gatb-core/thirdparty/hdf5/src/H5Odeprec.c
+++ b/gatb-core/thirdparty/hdf5/src/H5Odeprec.c
@@ -32,6 +32,7 @@
 /* Headers */
 /***********/
 #include "H5private.h"      /* Generic Functions    */
+#include "H5CXprivate.h"        /* API Contexts                             */
 #include "H5Eprivate.h"     /* Error handling       */
 #include "H5Opkg.h"         /* Object headers       */
 

--- a/gatb-core/thirdparty/kff-cpp-api/kff_io.hpp
+++ b/gatb-core/thirdparty/kff-cpp-api/kff_io.hpp
@@ -10,6 +10,7 @@
  *
  */
 
+#include <cstdint>
 #include <fstream>
 #include <unordered_map>
 #include <map>

--- a/gatb-core/thirdparty/kff-cpp-api/kff_io.hpp.in
+++ b/gatb-core/thirdparty/kff-cpp-api/kff_io.hpp.in
@@ -10,6 +10,7 @@
  *
  */
 
+#include <cstdint>
 #include <fstream>
 #include <unordered_map>
 #include <map>


### PR DESCRIPTION
See issue https://github.com/GATB/bcalm/issues/78 for context

While trying to compile for ARM Mac, got the following error in hdf5:
```
/Users/runner/work/kissplice-ci-clone/kissplice-ci-clone/bcalm/gatb-core/gatb-core/thirdparty/hdf5/src/H5Odeprec.c:141:8: error: call to undeclared function 'H5CX_set_apl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 if(H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE) < 0)
 ^
/Users/runner/work/kissplice-ci-clone/kissplice-ci-clone/bcalm/gatb-core/gatb-core/thirdparty/hdf5/src/H5Odeprec.c:195:8: error: call to undeclared function 'H5CX_set_apl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 if(H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE) < 0)
 ^
/Users/runner/work/kissplice-ci-clone/kissplice-ci-clone/bcalm/gatb-core/gatb-core/thirdparty/hdf5/src/H5Odeprec.c:322:8: error: call to undeclared function 'H5CX_set_apl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 if(H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE) < 0)
 ^
```

The long term fix is to use an up to date hdf5 (making it an external dependency ?). In the meantime add a header including the missing declaration.